### PR TITLE
Run tests on CI against TruffleRuby and Rails 7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,12 @@ jobs:
             ruby: 3.2
           - gemfile: gemfiles/rails_master.gemfile
             ruby: 3.2
+          # Stable TruffleRuby and Rails
+          - gemfile: gemfiles/rails_7.0.gemfile
+            ruby: truffleruby
+            experimental: true
+        experimental: [false]
+    continue-on-error: ${{ matrix.experimental }}
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,10 +60,7 @@ jobs:
             ruby: 3.2
           # Stable TruffleRuby and Rails
           - gemfile: gemfiles/rails_7.0.gemfile
-            ruby: truffleruby
-            experimental: true
-        experimental: [false]
-    continue-on-error: ${{ matrix.experimental }}
+            ruby: truffleruby-head
     runs-on: ubuntu-latest
     steps:
     - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV


### PR DESCRIPTION
Follow up on https://github.com/rmosolgo/graphql-ruby/pull/3852

Restore running TruffleRuby (stable release) on CI.